### PR TITLE
App crash when meta is null in mkfile

### DIFF
--- a/localfs.js
+++ b/localfs.js
@@ -338,6 +338,7 @@ module.exports = function setup(fsOptions) {
         var meta = {};
         var called;
         var callback = function (err, meta) {
+            meta = meta || {};
             if (called) {
                 if (err) {
                     if (meta.stream) meta.stream.emit("error", err);


### PR DESCRIPTION
Causes ajaxorg/cloud9#2713.
