### PR TITLE
pty.js version upgrade to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     ],
     "name": "vfs-local",
     "description": "A vfs implementation that works on the local filesystem.",
-    "version": "0.3.13",
+    "version": "0.3.14",
     "repository": {
         "type": "git",
         "url": "git://github.com/c9/vfs-local.git"
@@ -14,7 +14,7 @@
     "main": "localfs.js",
     "dependencies": {
         "simple-mime": "~0.0.7",
-	"pty.js": "0.2.3"
+        "pty.js": "0.3.0"
     },
     "devDependencies": {
         "chai": "~1.2.0",


### PR DESCRIPTION
Why?
Unable to install Node 4.1.1 - node-gyp rebuild fails
https://github.com/chjj/pty.js/issues/138#issuecomment-171832363

Signed-off-by: Jai <jai@doselect.com>